### PR TITLE
use p5js for docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
         },
         "processing.docsURL": {
           "type": "string",
-          "default": "https://p5js.org/reference/#/p5/",
+          "default": "",
           "description": "URL to Processing documentation; unused unless specifically selected in the processing.docs setting"
         },
         "processing.search": {
@@ -136,7 +136,7 @@
         },
         "processing.searchURL": {
           "type": "string",
-          "default": "https://p5js.org/reference/#/p5/",
+          "default": "",
           "description": "URL to Processing documentation, unused unless specifically selected in the processing.search setting"
         }
       }

--- a/package.json
+++ b/package.json
@@ -94,12 +94,50 @@
     },
     "configuration": {
       "type": "object",
-      "title": "Processing configuration",
+      "title": "Processing",
       "properties": {
         "processing.path": {
           "type": "string",
           "default": "processing-java",
           "description": "Path to Processing. Leave default if you've added processing to your path, otherwise enter the path to processing-java here. Example: 'C:\\Program Files\\processing-3.0.1\\processing-java' for Windows"
+        },
+        "processing.docs": {
+          "type": "string",
+          "default": "https://p5js.org/reference/#/p5/",
+          "enum": [
+            "https://p5js.org/reference/#/p5/",
+            "https://processing.org/reference/",
+            "other"
+          ],
+          "enumDescriptions": [
+            "Use p5js documentation",
+            "Use processing.org documentation",
+            "Use the URL given by the processing.docsURL setting"
+          ]
+        },
+        "processing.docsURL": {
+          "type": "string",
+          "default": "https://p5js.org/reference/#/p5/",
+          "description": "URL to Processing documentation; unused unless specifically selected in the processing.docs setting"
+        },
+        "processing.search": {
+          "type": "string",
+          "default": "https://p5js.org/reference/#/p5/",
+          "enum": [
+            "https://p5js.org/reference/#/p5/",
+            "https://www.google.com/search?as_sitesearch=processing.org&as_q=",
+            "other"
+          ],
+          "enumDescriptions": [
+            "Use p5js documentation for selections",
+            "Use processing.org documentation for selections via the Googleses",
+            "Use the URL given by the processing.searchURL setting"
+          ]
+        },
+        "processing.searchURL": {
+          "type": "string",
+          "default": "https://p5js.org/reference/#/p5/",
+          "description": "URL to Processing documentation, unused unless specifically selected in the processing.search setting"
         }
       }
     }

--- a/src/search.ts
+++ b/src/search.ts
@@ -1,5 +1,5 @@
-let processingDocs = 'https://processing.org/reference/';
-let processingSearch = 'https://www.google.com/search?as_sitesearch=processing.org&as_q=';
+let processingDocs = 'https://p5js.org/reference/#/p5/';
+let processingSearch = 'https://p5js.org/reference/#/p5/';
 
 import * as vscode from 'vscode';
 

--- a/src/search.ts
+++ b/src/search.ts
@@ -1,9 +1,16 @@
-let processingDocs = 'https://p5js.org/reference/#/p5/';
-let processingSearch = 'https://p5js.org/reference/#/p5/';
-
 import * as vscode from 'vscode';
 
 export async function openURL(search_base?: string, s?: string) {
+	const config = vscode.workspace.getConfiguration('processing');
+	let processingDocs = String(config.get('docs'));
+	if (processingDocs === 'other') {
+		processingDocs = String(config.get('docsURL'));
+	}
+	let processingSearch = String(config.get('search'));
+	if (processingSearch === 'other') {
+		processingSearch = String(config.get('searchURL'));
+	}
+
 	if (search_base === 'open') { await vscode.env.openExternal(vscode.Uri.parse(s as string)); } else {
 		if (!s) { s = processingDocs; }
 		else { s = processingSearch + s; }


### PR DESCRIPTION
IMO, p5js shows better docs than the google search, and the p5js url used here will go straight to the docs instead of having google as an intermediary.  Is this change cool with you?