### PR TITLE
Update snippets.json for better autocomplete

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -1,24 +1,24 @@
 {
-	"@": {
-		"prefix": "@",
+	"@param": {
+		"prefix": "@param",
 		"body": "@param  ${1:parameter}  ${2:description}",
 		"description": "@param",
 		"scope": "source.pde"
 	},
-	"@1": {
-		"prefix": "@",
+	"@private": {
+		"prefix": "@private",
 		"body": "@private",
 		"description": "@private",
 		"scope": "source.pde"
 	},
-	"@2": {
-		"prefix": "@",
+	"@public": {
+		"prefix": "@public",
 		"body": "@private",
 		"description": "@public",
 		"scope": "source.pde"
 	},
-	"@3": {
-		"prefix": "@",
+	"@return": {
+		"prefix": "@return",
 		"body": "@return  ${1:parameter}  ${2:description}",
 		"description": "@return",
 		"scope": "source.pde"
@@ -41,14 +41,14 @@
 		"description": "alpha",
 		"scope": "source.pde"
 	},
-	"material": {
-		"prefix": "material",
+	"ambient": {
+		"prefix": "ambient",
 		"body": "ambient(${8:${3:value1}, ${4:value2}, ${5:value3}});",
 		"description": "ambient",
 		"scope": "source.pde"
 	},
-	"light": {
-		"prefix": "light",
+	"ambientLight": {
+		"prefix": "ambientLight",
 		"body": "ambientLight(${1:v1}, ${2:v2}, ${3:v3}${7:, ${4:x}, ${5:y}, ${6:z}});",
 		"description": "ambientLight",
 		"scope": "source.pde"
@@ -65,20 +65,20 @@
 		"description": "arc",
 		"scope": "source.pde"
 	},
-	"array": {
-		"prefix": "array",
+	"Array": {
+		"prefix": "Array",
 		"body": "${1:int}[] ${2:numbers} ${6:= new $1[${3:length}]};",
 		"description": "Array",
 		"scope": "source.pde"
 	},
-	"arraycopy": {
-		"prefix": "arraycopy",
+	"arrayCopy": {
+		"prefix": "arrayCopy",
 		"body": "arrayCopy(${1:src}, ${2:dest}, ${4:, ${3:length}});",
 		"description": "arrayCopy",
 		"scope": "source.pde"
 	},
-	"arraylist": {
-		"prefix": "arraylist",
+	"ArrayList": {
+		"prefix": "ArrayList",
 		"body": "ArrayList<${1:String}> ${2:arraylist} = new ArrayList<$1>();",
 		"description": "ArrayList",
 		"scope": "source.pde"
@@ -101,26 +101,26 @@
 		"description": "atan2",
 		"scope": "source.pde"
 	},
-	"background": {
-		"prefix": "background",
+	"background_grey_alpha": {
+		"prefix": "background_grey_alpha",
 		"body": "background(${1:grey}, ${2:alpha});",
 		"description": "background grey alpha",
 		"scope": "source.pde"
 	},
-	"background1": {
-		"prefix": "background",
+	"background_grey": {
+		"prefix": "background_grey",
 		"body": "background(${1:grey});",
 		"description": "background grey",
 		"scope": "source.pde"
 	},
-	"background2": {
-		"prefix": "background",
+	"background_rgb": {
+		"prefix": "background_rgb",
 		"body": "background(${1:red}, ${2:green}, ${3:blue});",
 		"description": "background rgb",
 		"scope": "source.pde"
 	},
-	"background3": {
-		"prefix": "background",
+	"background_rgba": {
+		"prefix": "background_rgba",
 		"body": "background(${1:red}, ${2:green}, ${3:blue}, ${6:alpha});",
 		"description": "background rgba",
 		"scope": "source.pde"
@@ -131,26 +131,26 @@
 		"description": "background",
 		"scope": "source.pde"
 	},
-	"camera": {
-		"prefix": "camera",
+	"beginCamera": {
+		"prefix": "beginCamera",
 		"body": "beginCamera();",
 		"description": "beginCamera",
 		"scope": "source.pde"
 	},
-	"begingl": {
-		"prefix": "begingl",
+	"beginGL": {
+		"prefix": "beginGL",
 		"body": "pgl.beginGL();\n$1\npgl.endGL();",
 		"description": "beginGL",
 		"scope": "source.pde"
 	},
-	"file": {
-		"prefix": "file",
+	"beginRecord": {
+		"prefix": "beginRecord",
 		"body": "beginRecord(${1:renderer}, ${2:filename});",
 		"description": "beginRecord",
 		"scope": "source.pde"
 	},
-	"beginshape": {
-		"prefix": "beginshape",
+	"beginShape": {
+		"prefix": "beginShape",
 		"body": "beginShape(${1:kind});",
 		"description": "beginShape",
 		"scope": "source.pde"
@@ -161,38 +161,38 @@
 		"description": "bezier",
 		"scope": "source.pde"
 	},
-	"bezier1": {
-		"prefix": "bezier",
+	"bezier3D": {
+		"prefix": "bezier3D",
 		"body": "bezier(${1:x1}, ${2:y1}, ${3:z1}, ${4:cx1}, ${5:cy1}, ${6:cz1}, ${7:cx2}, ${8:cy2}, ${9:cz2}, ${10:x2}, ${11:y2}, ${12:z2});",
 		"description": "bezier3D",
 		"scope": "source.pde"
 	},
-	"bezier2": {
-		"prefix": "bezier",
+	"bezierDetail": {
+		"prefix": "bezierDetail",
 		"body": "bezierDetail(${1:detail});",
 		"description": "bezierDetail",
 		"scope": "source.pde"
 	},
-	"bezier3": {
-		"prefix": "bezier",
+	"bezierPoint": {
+		"prefix": "bezierPoint",
 		"body": "bezierPoint(${1:a}, ${1:b}, ${1:c}, ${1:d}, ${1:t});",
 		"description": "bezierPoint",
 		"scope": "source.pde"
 	},
-	"bezier4": {
-		"prefix": "bezier",
+	"bezierTangent": {
+		"prefix": "bezierTangent",
 		"body": "bezierTangent(${1:a}, ${1:b}, ${1:c}, ${1:d}, ${1:t});",
 		"description": "bezierTangent",
 		"scope": "source.pde"
 	},
-	"beziervertex": {
-		"prefix": "beziervertex",
+	"bezierVertex_3D": {
+		"prefix": "bezierVertex_3D",
 		"body": "bezierVertex(${1:cx1}, ${2:cy1}, ${3:cz1}, ${4:cx2}, ${5:cy2}, ${6:cz2}, ${7:x}, ${8:y}, ${9:z});",
 		"description": "bezierVertex 3D",
 		"scope": "source.pde"
 	},
-	"beziervertex1": {
-		"prefix": "beziervertex",
+	"bezierVertex": {
+		"prefix": "bezierVertex",
 		"body": "bezierVertex(${1:cx1}, ${2:cy1}, ${3:cx2}, ${4:cy2}, ${5:x}, ${6:y});",
 		"description": "bezierVertex",
 		"scope": "source.pde"
@@ -311,26 +311,26 @@
 		"description": "cos",
 		"scope": "source.pde"
 	},
-	"file1": {
-		"prefix": "file",
+	"createReader": {
+		"prefix": "createReader",
 		"body": "createReader(${1:filename});",
 		"description": "createReader",
 		"scope": "source.pde"
 	},
-	"createshape": {
-		"prefix": "createshape",
+	"createShape": {
+		"prefix": "createShape",
 		"body": "createShape(${1:type});",
 		"description": "createShape",
 		"scope": "source.pde"
 	},
-	"file2": {
-		"prefix": "file",
+	"createWriter": {
+		"prefix": "createWriter",
 		"body": "createWriter(${1:filename});",
 		"description": "createWriter",
 		"scope": "source.pde"
 	},
-	"curve": {
-		"prefix": "curve",
+	"curve_3D": {
+		"prefix": "curve_3D",
 		"body": "curve(${1:x1}, ${2:y1}, ${3:z1}, ${4:x2}, ${5:y2}, ${6:z2}, ${7:x3}, ${8:y3}, ${9:z3}, ${10:x4}, ${11:y4}, ${12:z4});",
 		"description": "curve 3D",
 		"scope": "source.pde"
@@ -341,26 +341,26 @@
 		"description": "curve",
 		"scope": "source.pde"
 	},
-	"curve2": {
-		"prefix": "curve",
+	"curveDetail": {
+		"prefix": "curveDetail",
 		"body": "curveDetail(${1:detail});",
 		"description": "curveDetail",
 		"scope": "source.pde"
 	},
-	"curve3": {
-		"prefix": "curve",
+	"curvePoint": {
+		"prefix": "curvePoint",
 		"body": "curvePoint(${1:a}, ${1:b}, ${1:c}, ${1:d}, ${1:t});",
 		"description": "curvePoint",
 		"scope": "source.pde"
 	},
-	"curve4": {
-		"prefix": "curve",
+	"curveTightness": {
+		"prefix": "curveTightness",
 		"body": "curveTightness(${1:squishy});",
 		"description": "curveTightness",
 		"scope": "source.pde"
 	},
-	"curveVertex": {
-		"prefix": "curveVertex",
+	"curveVertex_3D": {
+		"prefix": "curveVertex_3D",
 		"body": "curveVertex(${1:x}, ${2:y}, ${3:z});",
 		"description": "curveVertex 3D",
 		"scope": "source.pde"
@@ -383,14 +383,14 @@
 		"description": "degrees",
 		"scope": "source.pde"
 	},
-	"light1": {
-		"prefix": "light",
+	"directionalLight": {
+		"prefix": "directionalLight",
 		"body": "directionalLight(${1:v1}, ${2:v2}, ${3:v3}, ${4:nx}, ${5:ny}, ${6:nz});",
 		"description": "directionalLight",
 		"scope": "source.pde"
 	},
-	"dist": {
-		"prefix": "dist",
+	"dist_3D": {
+		"prefix": "dist_3D",
 		"body": "dist(${1:x1}, ${2:y1}, ${3:z1}, ${4:x2}, ${5:y2}, ${6:z2});",
 		"description": "dist 3D",
 		"scope": "source.pde"
@@ -401,14 +401,14 @@
 		"description": "dist",
 		"scope": "source.pde"
 	},
-	"doc": {
-		"prefix": "doc",
+	"doc_-_class": {
+		"prefix": "doc_-_class",
 		"body": "/**\n *  ${1:Description}\n *\n *\t@author ${2:$TM_FULLNAME}\n *\t@since  ${3:`date +%d.%m.%Y`}\n */",
 		"description": "doc - class",
 		"scope": "source.pde"
 	},
-	"doc1": {
-		"prefix": "doc",
+	"doc_-_comment": {
+		"prefix": "doc_-_comment",
 		"body": "/**\n *\t${1:@private}$0\n */",
 		"description": "doc - comment",
 		"scope": "source.pde"
@@ -425,8 +425,8 @@
 		"description": "ellipseMode",
 		"scope": "source.pde"
 	},
-	"else": {
-		"prefix": "else",
+	"else_if": {
+		"prefix": "else_if",
 		"body": "else if ($1) {\n\t$0\n}",
 		"description": "else if",
 		"scope": "source.pde"
@@ -437,26 +437,26 @@
 		"description": "else",
 		"scope": "source.pde"
 	},
-	"material1": {
-		"prefix": "material",
+	"emissive": {
+		"prefix": "emissive",
 		"body": "emissive(${8:${3:value1}, ${4:value2}, ${5:value3}});",
 		"description": "emissive",
 		"scope": "source.pde"
 	},
-	"camera2": {
-		"prefix": "camera",
+	"endCamera": {
+		"prefix": "endCamera",
 		"body": "endCamera();",
 		"description": "endCamera",
 		"scope": "source.pde"
 	},
-	"file3": {
-		"prefix": "file",
+	"endRecord": {
+		"prefix": "endRecord",
 		"body": "endRecord();",
 		"description": "endRecord",
 		"scope": "source.pde"
 	},
-	"endshape": {
-		"prefix": "endshape",
+	"endShape": {
+		"prefix": "endShape",
 		"body": "endShape(${1:mode});",
 		"description": "endShape",
 		"scope": "source.pde"
@@ -473,26 +473,26 @@
 		"description": "expand",
 		"scope": "source.pde"
 	},
-	"fill": {
-		"prefix": "fill",
+	"fill_grey_alpha": {
+		"prefix": "fill_grey_alpha",
 		"body": "fill(${1:grey}, ${2:alpha});",
 		"description": "fill grey alpha",
 		"scope": "source.pde"
 	},
-	"fill1": {
-		"prefix": "fill",
+	"fill_grey": {
+		"prefix": "fill_grey",
 		"body": "fill(${1:grey});",
 		"description": "fill grey",
 		"scope": "source.pde"
 	},
-	"fill2": {
-		"prefix": "fill",
+	"fill_rgb": {
+		"prefix": "fill_rgb",
 		"body": "fill(${1:red}, ${2:green}, ${3:blue});",
 		"description": "fill rgb",
 		"scope": "source.pde"
 	},
-	"fill3": {
-		"prefix": "fill",
+	"fill_rgba": {
+		"prefix": "fill_rgba",
 		"body": "fill(${1:red}, ${2:green}, ${3:blue}, ${6:alpha});",
 		"description": "fill rgba",
 		"scope": "source.pde"
@@ -521,8 +521,8 @@
 		"description": "focused",
 		"scope": "source.pde"
 	},
-	"for": {
-		"prefix": "for",
+	"for_in": {
+		"prefix": "for_in",
 		"body": "for (${1:Object} ${2:o} : ${3:array}) {\n\t$0\n}",
 		"description": "for in",
 		"scope": "source.pde"
@@ -533,26 +533,26 @@
 		"description": "for",
 		"scope": "source.pde"
 	},
-	"framerate": {
-		"prefix": "framerate",
+	"frameCount": {
+		"prefix": "frameCount",
 		"body": "frameCount",
 		"description": "frameCount",
 		"scope": "source.pde"
 	},
-	"framerate1": {
-		"prefix": "framerate",
+	"frameRate_(debug)": {
+		"prefix": "frameRate_(debug)",
 		"body": "frameRate",
 		"description": "frameRate (debug)",
 		"scope": "source.pde"
 	},
-	"framerate2": {
-		"prefix": "framerate",
+	"frameRate_(set)": {
+		"prefix": "frameRate_(set)",
 		"body": "frameRate($0);",
 		"description": "frameRate (set)",
 		"scope": "source.pde"
 	},
-	"camera3": {
-		"prefix": "camera",
+	"frustum": {
+		"prefix": "frustum",
 		"body": "frustrum(${7:${1:left}, ${2:right}, ${3:bottom}, ${4:top}, ${5:near}, ${6:far}});",
 		"description": "frustum",
 		"scope": "source.pde"
@@ -563,8 +563,8 @@
 		"description": "function",
 		"scope": "source.pde"
 	},
-	"get": {
-		"prefix": "get",
+	"get_pixel": {
+		"prefix": "get_pixel",
 		"body": "get(${6:${1:x}, ${2:y}${5:, ${3:width}, ${4:height}}});",
 		"description": "get pixel",
 		"scope": "source.pde"
@@ -575,122 +575,122 @@
 		"description": "get",
 		"scope": "source.pde"
 	},
-	"glbindbuffer": {
-		"prefix": "glbindbuffer",
+	"glBindBuffer": {
+		"prefix": "glBindBuffer",
 		"body": "${2:// A buffer ID of zero unbinds a buffer object}\ngl.glBindBuffer(GL.GL_ARRAY_BUFFER, ${1:0});",
 		"description": "glBindBuffer",
 		"scope": "source.pde"
 	},
-	"glcalllist": {
-		"prefix": "glcalllist",
+	"glCallList": {
+		"prefix": "glCallList",
 		"body": "// execute a display list\ngl.glCallList(${1:list});",
 		"description": "glCallList",
 		"scope": "source.pde"
 	},
-	"glclear": {
-		"prefix": "glclear",
+	"glClear": {
+		"prefix": "glClear",
 		"body": "gl.glClear(${1:GL.GL_COLOR_BUFFER_BIT}${3: | ${2:GL.GL_DEPTH_BUFFER_BIT}});",
 		"description": "glClear",
 		"scope": "source.pde"
 	},
-	"glclearcolor": {
-		"prefix": "glclearcolor",
+	"glClearColor": {
+		"prefix": "glClearColor",
 		"body": "gl.glClearColor(${1:red}, ${2:green}, ${3:blue}, ${4:alpha});",
 		"description": "glClearColor",
 		"scope": "source.pde"
 	},
-	"glcolor3f": {
-		"prefix": "glcolor3f",
+	"glColor3f": {
+		"prefix": "glColor3f",
 		"body": "gl.glColor3f(${1:red}, ${2:green}, ${3:blue});",
 		"description": "glColor3f",
 		"scope": "source.pde"
 	},
-	"glcolor4f": {
-		"prefix": "glcolor4f",
+	"glColor4f": {
+		"prefix": "glColor4f",
 		"body": "gl.glColor4f(${1:red}, ${2:green}, ${3:blue}, ${4:alpha});",
 		"description": "glColor4f",
 		"scope": "source.pde"
 	},
-	"gldeletebuffers": {
-		"prefix": "gldeletebuffers",
+	"glDeleteBuffers": {
+		"prefix": "glDeleteBuffers",
 		"body": "${3:// Parameters are the same for glGenBuffers}\ngl.glDeleteBuffers(${1:4}, ${2:bufferObjects});",
 		"description": "glDeleteBuffers",
 		"scope": "source.pde"
 	},
-	"gldepthmask": {
-		"prefix": "gldepthmask",
+	"glDepthMask": {
+		"prefix": "glDepthMask",
 		"body": "// enable or disable writing into the depth buffer\ngl.glDepthMask(${1:flag});",
 		"description": "glDepthMask",
 		"scope": "source.pde"
 	},
-	"glflush": {
-		"prefix": "glflush",
+	"glFlush": {
+		"prefix": "glFlush",
 		"body": "// Empties buffers. Call this when all previous issues commands completed\ngl.glFlush();",
 		"description": "glFlush",
 		"scope": "source.pde"
 	},
-	"glgenbuffers": {
-		"prefix": "glgenbuffers",
+	"glGenBuffers": {
+		"prefix": "glGenBuffers",
 		"body": "// import java.nio.IntBuffer;\n// import java.nio.FloatBuffer;\n// import com.sun.opengl.util.BufferUtil;\n\n// You might need to create four buffers to store vertext data, normal data, texture coordinate data, and indices in vertex arrays\nIntBuffer bufferObjects = IntBuffer.allocate(${1:4}); \ngl.glGenBuffers($1, bufferObjects);\n\nint vertexCount = ${2:3};\nint numCoordinates = ${3:3};\n// vertexCount * numCoordinates\nFloatBuffer vertices = BufferUtil.newFloatBuffer(vertexCount * numCoordinates);\nfloat[] v = {0.0f, 0.0f, 0.0f,\n             1.0f, 0.0f, 0.0f,\n             0.0f, 1.0f, 1.0f};\nvertices.put(v);\n\n// Bind the first buffer object ID for use with vertext array data\ngl.glBindBuffer(GL.GL_ARRAY_BUFFER, bufferObjects.get(0));\ngl.glBufferData(GL.GL_ARRAY_BUFFER, vertexCount * numCoordinates * BufferUtil.SIZEOF_FLOAT, vertices, GL.GL_STATIC_DRAW);",
 		"description": "glGenBuffers",
 		"scope": "source.pde"
 	},
-	"glgenlists": {
-		"prefix": "glgenlists",
+	"glGenLists": {
+		"prefix": "glGenLists",
 		"body": "gl.glGenLists(${1:1})",
 		"description": "glGenLists",
 		"scope": "source.pde"
 	},
-	"glgeterror": {
-		"prefix": "glgeterror",
+	"glGetError": {
+		"prefix": "glGetError",
 		"body": "println(gl.glGetError());",
 		"description": "glGetError",
 		"scope": "source.pde"
 	},
-	"glloadidentity": {
-		"prefix": "glloadidentity",
+	"glLoadIdentity": {
+		"prefix": "glLoadIdentity",
 		"body": "// replaces the top of the active matrix stack with the identity matrix\ngl.glLoadIdentity();",
 		"description": "glLoadIdentity",
 		"scope": "source.pde"
 	},
-	"glpushmatrix": {
-		"prefix": "glpushmatrix",
+	"glPushMatrix": {
+		"prefix": "glPushMatrix",
 		"body": "// spush and pop the current matrix stack\ngl.glPushMatrix();\n$1\ngl.glPopMatrix();",
 		"description": "glPushMatrix",
 		"scope": "source.pde"
 	},
-	"glrotatef": {
-		"prefix": "glrotatef",
+	"glRotatef": {
+		"prefix": "glRotatef",
 		"body": "// rotation in degrees, x coordinate of a vector, y coord., z coord.\ngl.glRotatef(${1:deg}, ${2:x}, ${3:y}, ${4:z});",
 		"description": "glRotatef",
 		"scope": "source.pde"
 	},
-	"glscalef": {
-		"prefix": "glscalef",
+	"glScalef": {
+		"prefix": "glScalef",
 		"body": "// multiply the current matrix by a general scaling matrix\ngl.glScalef(${1:x}, ${2:y}, ${3:z});",
 		"description": "glScalef",
 		"scope": "source.pde"
 	},
-	"gltexcoord2f": {
-		"prefix": "gltexcoord2f",
+	"glTexCoord2f": {
+		"prefix": "glTexCoord2f",
 		"body": "// set the current texture coordinates - 2 floats\ngl.glTexCoord2f(${1:0.0f}, ${2:0.0f});",
 		"description": "glTexCoord2f",
 		"scope": "source.pde"
 	},
-	"gltranslatef": {
-		"prefix": "gltranslatef",
+	"glTranslatef": {
+		"prefix": "glTranslatef",
 		"body": "// multiply the current matrix by a translation matrix\ngl.glTranslatef(${1:x}, ${2:y}, ${3:z});",
 		"description": "glTranslatef",
 		"scope": "source.pde"
 	},
-	"glvertex2f": {
-		"prefix": "glvertex2f",
+	"glVertex2f": {
+		"prefix": "glVertex2f",
 		"body": "gl.glVertex2f(${1:0.0f}, ${2:0.0f});",
 		"description": "glVertex2f",
 		"scope": "source.pde"
 	},
-	"glvertex3f": {
-		"prefix": "glvertex3f",
+	"glVertex3f": {
+		"prefix": "glVertex3f",
 		"body": "gl.glVertex3f(${1:0.0f}, ${2:0.0f}, ${3:0.0f});",
 		"description": "glVertex3f",
 		"scope": "source.pde"
@@ -701,8 +701,8 @@
 		"description": "green",
 		"scope": "source.pde"
 	},
-	"pi": {
-		"prefix": "pi",
+	"HALF_PI": {
+		"prefix": "HALF_PI",
 		"body": "HALF_PI",
 		"description": "HALF PI",
 		"scope": "source.pde"
@@ -713,8 +713,8 @@
 		"description": "hex",
 		"scope": "source.pde"
 	},
-	"time": {
-		"prefix": "time",
+	"hour": {
+		"prefix": "hour",
 		"body": "hour()",
 		"description": "hour",
 		"scope": "source.pde"
@@ -761,32 +761,32 @@
 		"description": "key",
 		"scope": "source.pde"
 	},
-	"key1": {
-		"prefix": "key",
+	"keyCode": {
+		"prefix": "keyCode",
 		"body": "keyCode",
 		"description": "keyCode",
 		"scope": "source.pde"
 	},
-	"key2": {
-		"prefix": "key",
-		"body": "keyPressed",
-		"description": "keyPressed",
-		"scope": "source.pde"
-	},
-	"key3": {
-		"prefix": "key",
+	"keyPressed_func": {
+		"prefix": "keyPressed",
 		"body": "void keyPressed() {\n\t${1}\n}",
 		"description": "keyPressed",
 		"scope": "source.pde"
 	},
-	"key4": {
-		"prefix": "key",
+	"keyPressed": {
+		"prefix": "keyPressed",
+		"body": "keyPressed",
+		"description": "keyPressed",
+		"scope": "source.pde"
+	},
+	"keyReleased": {
+		"prefix": "keyReleased",
 		"body": "void keyReleased() {\n\t${1}\n}",
 		"description": "keyReleased",
 		"scope": "source.pde"
 	},
-	"key5": {
-		"prefix": "key",
+	"keyTyped": {
+		"prefix": "keyTyped",
 		"body": "void keyTyped() {\n\t${1}\n}",
 		"description": "keyTyped",
 		"scope": "source.pde"
@@ -797,32 +797,32 @@
 		"description": "lerp",
 		"scope": "source.pde"
 	},
-	"lerpcolor": {
-		"prefix": "lerpcolor",
+	"lerpColor": {
+		"prefix": "lerpColor",
 		"body": "lerpColor(${1:c1}, ${2:c2}, ${3:amt});",
 		"description": "lerpColor",
 		"scope": "source.pde"
 	},
-	"light2": {
-		"prefix": "light",
+	"lightFalloff": {
+		"prefix": "lightFalloff",
 		"body": "lightFalloff(${1:constant}, ${2:linear}, ${3:quadratic});",
 		"description": "lightFalloff",
 		"scope": "source.pde"
 	},
-	"light3": {
-		"prefix": "light",
+	"lights": {
+		"prefix": "lights",
 		"body": "lights();",
 		"description": "lights",
 		"scope": "source.pde"
 	},
-	"light4": {
-		"prefix": "light",
+	"lightSpecular": {
+		"prefix": "lightSpecular",
 		"body": "lightFalloff(${1:v1}, ${2:v2}, ${3:v3});",
 		"description": "lightSpecular",
 		"scope": "source.pde"
 	},
-	"line": {
-		"prefix": "line",
+	"line_3d": {
+		"prefix": "line_3d",
 		"body": "line(${1:x1}, ${2:y1}, ${3:z1}, ${4:x2}, ${5:y2}, ${6:z2});",
 		"description": "line 3d",
 		"scope": "source.pde"
@@ -839,44 +839,44 @@
 		"description": "link",
 		"scope": "source.pde"
 	},
-	"load": {
-		"prefix": "load",
+	"loadBytes": {
+		"prefix": "loadBytes",
 		"body": "loadBytes(${2:\"${1:filename}\"});",
 		"description": "loadBytes",
 		"scope": "source.pde"
 	},
-	"font": {
-		"prefix": "font",
+	"loadFont": {
+		"prefix": "loadFont",
 		"body": "${1:font} = loadFont(${3:\"${2:FFScala-32.vlw}\"});",
 		"description": "loadFont",
 		"scope": "source.pde"
 	},
-	"loadimage": {
-		"prefix": "loadimage",
+	"loadImage": {
+		"prefix": "loadImage",
 		"body": "loadImage(${1:filename});",
 		"description": "loadImage",
 		"scope": "source.pde"
 	},
-	"loadpixels": {
-		"prefix": "loadpixels",
+	"loadPixels": {
+		"prefix": "loadPixels",
 		"body": "loadPixels();",
 		"description": "loadPixels",
 		"scope": "source.pde"
 	},
-	"loadshape": {
-		"prefix": "loadshape",
+	"loadShape": {
+		"prefix": "loadShape",
 		"body": "loadShape(${1:filename});",
 		"description": "loadShape",
 		"scope": "source.pde"
 	},
-	"load1": {
-		"prefix": "load",
+	"loadStrings": {
+		"prefix": "loadStrings",
 		"body": "loadStrings(${2:\"${1:filename}\"});",
 		"description": "loadStrings",
 		"scope": "source.pde"
 	},
-	"loadx": {
-		"prefix": "loadx",
+	"loadXML": {
+		"prefix": "loadXML",
 		"body": "loadXML(${2:\"${1:filename}\"});",
 		"description": "loadXML",
 		"scope": "source.pde"
@@ -905,8 +905,8 @@
 		"description": "match",
 		"scope": "source.pde"
 	},
-	"max": {
-		"prefix": "max",
+	"max_array": {
+		"prefix": "max_array",
 		"body": "max(${1:array});",
 		"description": "max array",
 		"scope": "source.pde"
@@ -917,14 +917,14 @@
 		"description": "max",
 		"scope": "source.pde"
 	},
-	"time1": {
-		"prefix": "time",
+	"millis": {
+		"prefix": "millis",
 		"body": "millis()",
 		"description": "millis",
 		"scope": "source.pde"
 	},
-	"min": {
-		"prefix": "min",
+	"min_array": {
+		"prefix": "min_array",
 		"body": "min(${1:array}};",
 		"description": "min array",
 		"scope": "source.pde"
@@ -935,80 +935,80 @@
 		"description": "min",
 		"scope": "source.pde"
 	},
-	"time2": {
-		"prefix": "time",
+	"minute": {
+		"prefix": "minute",
 		"body": "minute()",
 		"description": "minute",
 		"scope": "source.pde"
 	},
-	"coordinates": {
-		"prefix": "coordinates",
+	"modelX": {
+		"prefix": "modelX",
 		"body": "modelX(${1:x}, ${2:y}, ${3:z});",
 		"description": "modelX",
 		"scope": "source.pde"
 	},
-	"coordinates1": {
-		"prefix": "coordinates",
+	"modelY": {
+		"prefix": "modelY",
 		"body": "modelY(${1:x}, ${2:y}, ${3:z});",
 		"description": "modelY",
 		"scope": "source.pde"
 	},
-	"coordinates2": {
-		"prefix": "coordinates",
+	"modelZ": {
+		"prefix": "modelZ",
 		"body": "modelZ(${1:x}, ${2:y}, ${3:z});",
 		"description": "modelZ",
 		"scope": "source.pde"
 	},
-	"time3": {
-		"prefix": "time",
+	"month": {
+		"prefix": "month",
 		"body": "month()",
 		"description": "month",
 		"scope": "source.pde"
 	},
-	"mouse": {
-		"prefix": "mouse",
+	"mouseButton": {
+		"prefix": "mouseButton",
 		"body": "mouseButton",
 		"description": "mouseButton",
 		"scope": "source.pde"
 	},
-	"mouse1": {
-		"prefix": "mouse",
+	"mouseDragged": {
+		"prefix": "mouseDragged",
 		"body": "void mouseDragged() {\n\t${1}\n}",
 		"description": "mouseDragged",
 		"scope": "source.pde"
 	},
-	"mouse2": {
-		"prefix": "mouse",
+	"mouseMoved": {
+		"prefix": "mouseMoved",
 		"body": "void mouseMoved() {\n\t${1}\n}",
 		"description": "mouseMoved",
 		"scope": "source.pde"
 	},
-	"mouse3": {
-		"prefix": "mouse",
+	"mousePressed": {
+		"prefix": "mousePressed",
 		"body": "mousePressed",
 		"description": "mousePressed",
 		"scope": "source.pde"
 	},
-	"mouse4": {
-		"prefix": "mouse",
+	"mousePressed_func": {
+		"prefix": "mousePressed",
 		"body": "void mousePressed() {\n\t${1}\n}",
 		"description": "mousePressed",
 		"scope": "source.pde"
 	},
-	"mouse5": {
-		"prefix": "mouse",
+	"mouseReleased": {
+		"prefix": "mouseReleased",
 		"body": "void mouseReleased() {\n\t${1}\n}",
 		"description": "mouseReleased",
 		"scope": "source.pde"
 	},
-	"mouse6": {
-		"prefix": "mouse",
+	"mouseX": {
+		"prefix": "mouseX",
 		"body": "mouseX",
 		"description": "mouseX",
 		"scope": "source.pde"
 	},
-	"mouse7": {
-		"prefix": "mouse",
+	"mouseY": {
+		"prefix": "mouseY",
 		"body": "mouseY",
 		"description": "mouseY",
 		"scope": "source.pde"
@@ -1037,14 +1037,14 @@
 		"description": "nfs",
 		"scope": "source.pde"
 	},
-	"cursor": {
-		"prefix": "cursor",
+	"noCursor": {
+		"prefix": "noCursor",
 		"body": "noCursor();",
 		"description": "noCursor",
 		"scope": "source.pde"
 	},
-	"nofill": {
-		"prefix": "nofill",
+	"noFill": {
+		"prefix": "noFill",
 		"body": "noFill();",
 		"description": "noFill",
 		"scope": "source.pde"
@@ -1055,20 +1055,20 @@
 		"description": "noise",
 		"scope": "source.pde"
 	},
-	"noisedetail": {
-		"prefix": "noisedetail",
+	"noiseDetail": {
+		"prefix": "noiseDetail",
 		"body": "noiseDetail(${1:octaves}${4:, ${3:falloff}});",
 		"description": "noiseDetail",
 		"scope": "source.pde"
 	},
-	"noiseseed": {
-		"prefix": "noiseseed",
+	"noiseSeed": {
+		"prefix": "noiseSeed",
 		"body": "noiseSeed(${1:x});",
 		"description": "noiseSeed",
 		"scope": "source.pde"
 	},
-	"light5": {
-		"prefix": "light",
+	"noLights": {
+		"prefix": "noLights",
 		"body": "noLights();",
 		"description": "noLights",
 		"scope": "source.pde"
@@ -1079,32 +1079,32 @@
 		"description": "norm",
 		"scope": "source.pde"
 	},
-	"light6": {
-		"prefix": "light",
+	"normal": {
+		"prefix": "normal",
 		"body": "normal(${1:nx}, ${2:ny}, ${3:nz});",
 		"description": "normal",
 		"scope": "source.pde"
 	},
-	"smooth": {
-		"prefix": "smooth",
+	"noSmooth": {
+		"prefix": "noSmooth",
 		"body": "noSmooth();",
 		"description": "noSmooth",
 		"scope": "source.pde"
 	},
-	"nostroke": {
-		"prefix": "nostroke",
+	"noStroke": {
+		"prefix": "noStroke",
 		"body": "noStroke();",
 		"description": "noStroke",
 		"scope": "source.pde"
 	},
-	"notint": {
-		"prefix": "notint",
+	"noTint": {
+		"prefix": "noTint",
 		"body": "noTint();",
 		"description": "noTint",
 		"scope": "source.pde"
 	},
-	"object": {
-		"prefix": "object",
+	"Object": {
+		"prefix": "Object",
 		"body": "${1:Object} ${2:o}${4: = new ${1}($3)};",
 		"description": "Object",
 		"scope": "source.pde"
@@ -1115,8 +1115,8 @@
 		"description": "online",
 		"scope": "source.pde"
 	},
-	"camera4": {
-		"prefix": "camera",
+	"ortho": {
+		"prefix": "ortho",
 		"body": "ortho(${7:${1:left}, ${2:right}, ${3:bottom}, ${4:top}, ${5:near}, ${6:far}});",
 		"description": "ortho",
 		"scope": "source.pde"
@@ -1133,38 +1133,38 @@
 		"description": "param",
 		"scope": "source.pde"
 	},
-	"parse": {
-		"prefix": "parse",
+	"parseXML": {
+		"prefix": "parseXML",
 		"body": "parseXML(${1:rawString});",
 		"description": "parseXML",
 		"scope": "source.pde"
 	},
-	"camera5": {
-		"prefix": "camera",
+	"perspective": {
+		"prefix": "perspective",
 		"body": "perspective(${5:${1:fov}, ${2:aspect}, ${3:zNear}, ${4:zFar}});",
 		"description": "perspective",
 		"scope": "source.pde"
 	},
-	"font1": {
-		"prefix": "font",
+	"PFont": {
+		"prefix": "PFont",
 		"body": "PFont ${1:font};\n$1 = loadFont(${3:\"${2:FFScala-32.vlw}\"});",
 		"description": "PFont",
 		"scope": "source.pde"
 	},
-	"pgraphics": {
-		"prefix": "pgraphics",
+	"PGraphics": {
+		"prefix": "PGraphics",
 		"body": "PGraphics pg;\npg = createGraphics(${5:${1:width}, ${2:height}${4:, ${3:applet}}});",
 		"description": "PGraphics",
 		"scope": "source.pde"
 	},
-	"pi1": {
-		"prefix": "pi",
+	"PI": {
+		"prefix": "PI",
 		"body": "PI",
 		"description": "PI",
 		"scope": "source.pde"
 	},
-	"pimage": {
-		"prefix": "pimage",
+	"PImage": {
+		"prefix": "PImage",
 		"body": "PImage(${1:width}, ${2:height});",
 		"description": "PImage",
 		"scope": "source.pde"
@@ -1175,14 +1175,14 @@
 		"description": "pixels",
 		"scope": "source.pde"
 	},
-	"mouse8": {
-		"prefix": "mouse",
+	"pmouseX": {
+		"prefix": "pmouseX",
 		"body": "pmouseX",
 		"description": "pmouseX",
 		"scope": "source.pde"
 	},
-	"mouse9": {
-		"prefix": "mouse",
+	"pmouseY": {
+		"prefix": "pmouseY",
 		"body": "pmouseY",
 		"description": "pmouseY",
 		"scope": "source.pde"
@@ -1193,8 +1193,8 @@
 		"description": "point",
 		"scope": "source.pde"
 	},
-	"light7": {
-		"prefix": "light",
+	"pointLight": {
+		"prefix": "pointLight",
 		"body": "pointLight(${1:v1}, ${2:v2}, ${3:v3}, ${4:nx}, ${5:ny}, ${6:nz});",
 		"description": "pointLight",
 		"scope": "source.pde"
@@ -1205,116 +1205,116 @@
 		"description": "pow",
 		"scope": "source.pde"
 	},
-	"camera6": {
-		"prefix": "camera",
+	"printCamera": {
+		"prefix": "printCamera",
 		"body": "printCamera();",
 		"description": "printCamera",
 		"scope": "source.pde"
 	},
-	"println": {
-		"prefix": "println",
+	"println_var": {
+		"prefix": "println_var",
 		"body": "println(\"${1:var}: \"+${1:var});$0",
 		"description": "println var",
 		"scope": "source.pde"
 	},
-	"println1": {
-		"prefix": "println",
+	"println_text": {
+		"prefix": "println_text",
 		"body": "println(\"$1\");$0",
 		"description": "println text",
 		"scope": "source.pde"
 	},
-	"matrix": {
-		"prefix": "matrix",
+	"printMatrix": {
+		"prefix": "printMatrix",
 		"body": "printMatrix();",
 		"description": "printMatrix",
 		"scope": "source.pde"
 	},
-	"camera7": {
-		"prefix": "camera",
+	"printProjection": {
+		"prefix": "printProjection",
 		"body": "printProjection();",
 		"description": "printProjection",
 		"scope": "source.pde"
 	},
-	"private": {
-		"prefix": "private",
+	"private_function": {
+		"prefix": "private_function",
 		"body": "private ${1:void} ${2:name}($3) {\n\t$0${1/void$|(.+)/(?1:return null;)/}\n}",
 		"description": "private function",
 		"scope": "source.pde"
 	},
-	"private1": {
-		"prefix": "private",
+	"private_static_function": {
+		"prefix": "private_static_function",
 		"body": "private static ${1:void} ${2:name}($3) {\n\t$0${1/void$|(.+)/(?1:return null;)/}\n}",
 		"description": "private static function",
 		"scope": "source.pde"
 	},
-	"private2": {
-		"prefix": "private",
+	"private_static_var": {
+		"prefix": "private_static_var",
 		"body": "private static ${1:String} ${2:str}${4: = ${3:value}};",
 		"description": "private static var",
 		"scope": "source.pde"
 	},
-	"private3": {
-		"prefix": "private",
+	"private_var_object": {
+		"prefix": "private_var_object",
 		"body": "private ${1:Object} ${2:o}${4: = new ${1}($3)};",
 		"description": "private var object",
 		"scope": "source.pde"
 	},
-	"private4": {
-		"prefix": "private",
+	"private_var": {
+		"prefix": "private_var",
 		"body": "private ${1:String} ${2:str}${4: = ${3:value}};",
 		"description": "private var",
 		"scope": "source.pde"
 	},
-	"protected": {
-		"prefix": "protected",
+	"protected_function": {
+		"prefix": "protected_function",
 		"body": "protected ${1:void} ${2:name}($3) {\n\t$0${1/void$|(.+)/(?1:return null;)/}\n}",
 		"description": "protected function",
 		"scope": "source.pde"
 	},
-	"protected1": {
-		"prefix": "protected",
+	"protected_var_object": {
+		"prefix": "protected_var_object",
 		"body": "protected ${1:Object} ${2:o}${4: = new ${1}($3)};",
 		"description": "protected var object",
 		"scope": "source.pde"
 	},
-	"protected2": {
-		"prefix": "protected",
+	"protected_var": {
+		"prefix": "protected_var",
 		"body": "protected ${1:String} ${2:str}${4: = ${3:value}};",
 		"description": "protected var",
 		"scope": "source.pde"
 	},
-	"public": {
-		"prefix": "public",
+	"public_function": {
+		"prefix": "public_function",
 		"body": "public ${1:void} ${2:name}($3) {\n\t$0${1/void$|(.+)/(?1:return null;)/}\n}",
 		"description": "public function",
 		"scope": "source.pde"
 	},
-	"public1": {
-		"prefix": "public",
+	"public_static_function": {
+		"prefix": "public_static_function",
 		"body": "public static ${1:void} ${2:name}($3) {\n\t$0${1/void$|(.+)/(?1:return null;)/}\n}",
 		"description": "public static function",
 		"scope": "source.pde"
 	},
-	"public2": {
-		"prefix": "public",
+	"public_static_var": {
+		"prefix": "public_static_var",
 		"body": "public static ${1:String} ${2:str}${4: = ${3:value}};",
 		"description": "public static var",
 		"scope": "source.pde"
 	},
-	"public3": {
-		"prefix": "public",
+	"public_var_object": {
+		"prefix": "public_var_object",
 		"body": "public ${1:Object} ${2:o}${4: = new ${1}($3)};",
 		"description": "public var object",
 		"scope": "source.pde"
 	},
-	"public4": {
-		"prefix": "public",
+	"public_var": {
+		"prefix": "public_var",
 		"body": "public ${1:String} ${2:str}${4: = ${3:value}};",
 		"description": "public var",
 		"scope": "source.pde"
 	},
-	"matrix1": {
-		"prefix": "matrix",
+	"pushMatrix/popMatrix": {
+		"prefix": "pushMatrix/popMatrix",
 		"body": "pushMatrix();\n${1:}\npopMatrix();",
 		"description": "pushMatrix/popMatrix",
 		"scope": "source.pde"
@@ -1337,14 +1337,14 @@
 		"description": "random",
 		"scope": "source.pde"
 	},
-	"random1": {
-		"prefix": "random",
+	"randomGaussian": {
+		"prefix": "randomGaussian",
 		"body": "randomGaussian();",
 		"description": "randomGaussian",
 		"scope": "source.pde"
 	},
-	"random2": {
-		"prefix": "random",
+	"randomSeed": {
+		"prefix": "randomSeed",
 		"body": "randomSeed(${1:value});",
 		"description": "randomSeed",
 		"scope": "source.pde"
@@ -1355,8 +1355,8 @@
 		"description": "rect",
 		"scope": "source.pde"
 	},
-	"rect1": {
-		"prefix": "rect",
+	"rectMode": {
+		"prefix": "rectMode",
 		"body": "rectMode(${1:CENTER});",
 		"description": "rectMode",
 		"scope": "source.pde"
@@ -1367,8 +1367,8 @@
 		"description": "red",
 		"scope": "source.pde"
 	},
-	"matrix2": {
-		"prefix": "matrix",
+	"resetMatrix": {
+		"prefix": "resetMatrix",
 		"body": "translate(${1:x}, ${2:y}, ${3:z});",
 		"description": "resetMatrix",
 		"scope": "source.pde"
@@ -1391,14 +1391,14 @@
 		"description": "rotateX",
 		"scope": "source.pde"
 	},
-	"rotate1": {
-		"prefix": "rotate",
+	"rotateY": {
+		"prefix": "rotateY",
 		"body": "rotateY(${1:rad});",
 		"description": "rotateY",
 		"scope": "source.pde"
 	},
-	"rotate2": {
-		"prefix": "rotate",
+	"rotateZ": {
+		"prefix": "rotateZ",
 		"body": "rotateZ(${1:rad});",
 		"description": "rotateZ",
 		"scope": "source.pde"
@@ -1421,32 +1421,32 @@
 		"description": "save",
 		"scope": "source.pde"
 	},
-	"file4": {
-		"prefix": "file",
+	"saveBytes": {
+		"prefix": "saveBytes",
 		"body": "saveBytes(${1:filename}, ${2:bytes});",
 		"description": "saveBytes",
 		"scope": "source.pde"
 	},
-	"save1": {
-		"prefix": "save",
+	"saveFrame": {
+		"prefix": "saveFrame",
 		"body": "saveFrame(${2:\"${1:filename-####.ext}\"});",
 		"description": "saveFrame",
 		"scope": "source.pde"
 	},
-	"file5": {
-		"prefix": "file",
+	"saveStrings": {
+		"prefix": "saveStrings",
 		"body": "saveStrings(${1:filename}, ${2:strings});",
 		"description": "saveStrings",
 		"scope": "source.pde"
 	},
-	"savex": {
-		"prefix": "savex",
+	"saveXML": {
+		"prefix": "saveXML",
 		"body": "saveXML(${1:xml}, ${2:filename});",
 		"description": "saveXML",
 		"scope": "source.pde"
 	},
-	"scale": {
-		"prefix": "scale",
+	"scale_SIZE": {
+		"prefix": "scale_SIZE",
 		"body": "scale(${1:size});",
 		"description": "scale SIZE",
 		"scope": "source.pde"
@@ -1457,44 +1457,44 @@
 		"description": "scale",
 		"scope": "source.pde"
 	},
-	"coordinates3": {
-		"prefix": "coordinates",
+	"screenX": {
+		"prefix": "screenX",
 		"body": "screenX(${1:x}, ${2:y}, ${3:z});",
 		"description": "screenX",
 		"scope": "source.pde"
 	},
-	"coordinates4": {
-		"prefix": "coordinates",
+	"screenY": {
+		"prefix": "screenY",
 		"body": "screenY(${1:x}, ${2:y}, ${3:z});",
 		"description": "screenY",
 		"scope": "source.pde"
 	},
-	"coordinates5": {
-		"prefix": "coordinates",
+	"screenZ": {
+		"prefix": "screenZ",
 		"body": "screenZ(${1:x}, ${2:y}, ${3:z});",
 		"description": "screenZ",
 		"scope": "source.pde"
 	},
-	"screen": {
-		"prefix": "screen",
+	"screen.height": {
+		"prefix": "screen.height",
 		"body": "screen.height",
 		"description": "screen.height",
 		"scope": "source.pde"
 	},
-	"screen1": {
-		"prefix": "screen",
+	"screen.width": {
+		"prefix": "screen.width",
 		"body": "screen.width",
 		"description": "screen.width",
 		"scope": "source.pde"
 	},
-	"time4": {
-		"prefix": "time",
+	"second": {
+		"prefix": "second",
 		"body": "second()",
 		"description": "second",
 		"scope": "source.pde"
 	},
-	"set": {
-		"prefix": "set",
+	"set_pixel": {
+		"prefix": "set_pixel",
 		"body": "set(${1:x}, ${2:y}, ${3:color/image});",
 		"description": "set pixel",
 		"scope": "source.pde"
@@ -1505,14 +1505,14 @@
 		"description": "set",
 		"scope": "source.pde"
 	},
-	"glswapinterval": {
-		"prefix": "glswapinterval",
+	"setSwapInterval": {
+		"prefix": "setSwapInterval",
 		"body": "// specify the minimum swap interval for buffer swaps.\ngl.setSwapInterval(${1:interval});",
 		"description": "setSwapInterval",
 		"scope": "source.pde"
 	},
-	"setup": {
-		"prefix": "setup",
+	"setup_OpenGL": {
+		"prefix": "setup_OpenGL",
 		"body": "import processing.opengl.*;\nimport javax.media.opengl.*;\n\nPGraphicsOpenGL pgl;\nGL gl;\n\nvoid setup() {\n\tsize( ${1:300}, ${2:300}, OPENGL );\n\tcolorMode( RGB, 1.0 );\n\thint( ENABLE_OPENGL_4X_SMOOTH );\n\tpgl = (PGraphicsOpenGL) g;\n\tgl = pgl.gl;\n\tgl.setSwapInterval(1);\n\tinitGL();\n\t$3\n}\n\nvoid draw() {\n\tpgl.beginGL();\n  \t$4\n\tpgl.endGL();\n\tgetOpenGLErrors();\n}\n\nvoid initGL() {\n\t$5\n}\n\nvoid getOpenGLErrors() {\n  int error = gl.glGetError();\n  switch (error) {\n    case 1280 :\n      println(\"GL_INVALID_ENUM - An invalid enumerant was passed to an OpenGL command.\");\n    break;\n    case 1282 :\n      println(\"GL_INVALID_OPERATION - An OpenGL command was issued that was invalid or inappropriate for the current state.\");\n    break;\n    case 1281 :\n      println(\"GL_INVALID_VALUE - A value was passed to OpenGL that was outside the allowed range.\");\n    break;\n    case 1285 :\n      println(\"GL_OUT_OF_MEMORY - OpenGL was unable to allocate enough memory to process a command.\");\n    break;\n    case 1283 :\n      println(\"GL_STACK_OVERFLOW - A command caused an OpenGL stack to overflow.\");\n    break;\n    case 1284 :\n      println(\"GL_STACK_UNDERFLOW - A command caused an OpenGL stack to underflow.\");\n    break;\n    case 32817 :\n      println(\"GL_TABLE_TOO_LARGE\");\n    break;\n  }\n}",
 		"description": "setup OpenGL",
 		"scope": "source.pde"
@@ -1529,14 +1529,14 @@
 		"description": "shape",
 		"scope": "source.pde"
 	},
-	"shapemode": {
-		"prefix": "shapemode",
+	"shapeMode": {
+		"prefix": "shapeMode",
 		"body": "shapeMode(${1:CENTER});",
 		"description": "shapeMode",
 		"scope": "source.pde"
 	},
-	"material2": {
-		"prefix": "material",
+	"shininess": {
+		"prefix": "shininess",
 		"body": "shininess(${1:shine});",
 		"description": "shininess",
 		"scope": "source.pde"
@@ -1553,8 +1553,8 @@
 		"description": "sin",
 		"scope": "source.pde"
 	},
-	"size": {
-		"prefix": "size",
+	"size_OPENGL": {
+		"prefix": "size_OPENGL",
 		"body": "size(${1:200}, ${2:200}${3:, OPENGL});",
 		"description": "size OPENGL",
 		"scope": "source.pde"
@@ -1577,8 +1577,8 @@
 		"description": "sort",
 		"scope": "source.pde"
 	},
-	"material3": {
-		"prefix": "material",
+	"specular": {
+		"prefix": "specular",
 		"body": "specular(${8:${3:value1}, ${4:value2}, ${5:value3}${7:, ${6:alpha}}});",
 		"description": "specular",
 		"scope": "source.pde"
@@ -1589,8 +1589,8 @@
 		"description": "sphere",
 		"scope": "source.pde"
 	},
-	"sphere1": {
-		"prefix": "sphere",
+	"sphereDetail": {
+		"prefix": "sphereDetail",
 		"body": "sphereDetail(${1:n});",
 		"description": "sphereDetail",
 		"scope": "source.pde"
@@ -1607,14 +1607,14 @@
 		"description": "split",
 		"scope": "source.pde"
 	},
-	"split1": {
-		"prefix": "split",
+	"splitTokens": {
+		"prefix": "splitTokens",
 		"body": "splitTokens(${3:str}${5:, ${4:tokens}});",
 		"description": "splitTokens",
 		"scope": "source.pde"
 	},
-	"light8": {
-		"prefix": "light",
+	"spotLight": {
+		"prefix": "spotLight",
 		"body": "spotLight(${1:v1}, ${2:v2}, ${3:v3}, ${4:x}, ${5:y}, ${6:z}, ${7:nx}, ${8:ny}, ${9:nz}, ${10:angle}, ${11:concentration});",
 		"description": "spotLight",
 		"scope": "source.pde"
@@ -1643,32 +1643,32 @@
 		"description": "str",
 		"scope": "source.pde"
 	},
-	"string": {
-		"prefix": "string",
+	"String": {
+		"prefix": "String",
 		"body": "String ${1:str} ${6:= \"${3:CCCP}\"};",
 		"description": "String",
 		"scope": "source.pde"
 	},
-	"stroke": {
-		"prefix": "stroke",
+	"stroke_grey_alpha": {
+		"prefix": "stroke_grey_alpha",
 		"body": "stroke(${1:grey}, ${2:alpha});",
 		"description": "stroke grey alpha",
 		"scope": "source.pde"
 	},
-	"stroke1": {
-		"prefix": "stroke",
+	"stroke_grey": {
+		"prefix": "stroke_grey",
 		"body": "stroke(${1:grey});",
 		"description": "stroke grey",
 		"scope": "source.pde"
 	},
-	"stroke2": {
-		"prefix": "stroke",
+	"stroke_rgb": {
+		"prefix": "stroke_rgb",
 		"body": "stroke(${1:red}, ${2:green}, ${3:blue});",
 		"description": "stroke rgb",
 		"scope": "source.pde"
 	},
-	"stroke3": {
-		"prefix": "stroke",
+	"stroke_rgba": {
+		"prefix": "stroke_rgba",
 		"body": "stroke(${1:red}, ${2:green}, ${3:blue}, ${6:alpha});",
 		"description": "stroke rgba",
 		"scope": "source.pde"
@@ -1679,8 +1679,8 @@
 		"description": "stroke",
 		"scope": "source.pde"
 	},
-	"stroke5": {
-		"prefix": "stroke",
+	"strokeWeight": {
+		"prefix": "strokeWeight",
 		"body": "strokeWeight(${1:1});",
 		"description": "strokeWeight",
 		"scope": "source.pde"
@@ -1703,50 +1703,50 @@
 		"description": "tan",
 		"scope": "source.pde"
 	},
-	"text": {
-		"prefix": "text",
+	"text_data": {
+		"prefix": "text_data",
 		"body": "text(${1:data}, ${2:x}, ${3:y}${5:, ${4:z}});",
 		"description": "text data",
 		"scope": "source.pde"
 	},
-	"text1": {
-		"prefix": "text",
+	"text_stringdata": {
+		"prefix": "text_stringdata",
 		"body": "text(${1:stringdata}, ${2:x}, ${3:y}, ${4:width}, ${5:height}${7:, ${6:z}});",
 		"description": "text stringdata",
 		"scope": "source.pde"
 	},
-	"text2": {
-		"prefix": "text",
+	"textAscent": {
+		"prefix": "textAscent",
 		"body": "textAscent();",
 		"description": "textAscent",
 		"scope": "source.pde"
 	},
-	"text3": {
-		"prefix": "text",
+	"textDescent": {
+		"prefix": "textDescent",
 		"body": "textDescent();",
 		"description": "textDescent",
 		"scope": "source.pde"
 	},
-	"text4": {
-		"prefix": "text",
+	"textFont": {
+		"prefix": "textFont",
 		"body": "textFont(${1:font}${7:, ${6:size}});",
 		"description": "textFont",
 		"scope": "source.pde"
 	},
-	"text5": {
-		"prefix": "text",
+	"textLeading": {
+		"prefix": "textLeading",
 		"body": "textLeading(${1:size});",
 		"description": "textLeading",
 		"scope": "source.pde"
 	},
-	"text6": {
-		"prefix": "text",
+	"textSize": {
+		"prefix": "textSize",
 		"body": "textSize(${1:size});",
 		"description": "textSize",
 		"scope": "source.pde"
 	},
-	"text7": {
-		"prefix": "text",
+	"textWidth": {
+		"prefix": "textWidth",
 		"body": "textWidth(${1:data});",
 		"description": "textWidth",
 		"scope": "source.pde"
@@ -1787,20 +1787,20 @@
 		"description": "try",
 		"scope": "source.pde"
 	},
-	"try1": {
-		"prefix": "try",
+	"try..catch": {
+		"prefix": "try..catch",
 		"body": "try {\n\t$1\n} catch (${2:Exception} e) {\n\t$3\n}",
 		"description": "try..catch",
 		"scope": "source.pde"
 	},
-	"try2": {
-		"prefix": "try",
+	"try..catch..finally": {
+		"prefix": "try..catch..finally",
 		"body": "try {\n\t$1\n} catch (${2:Exception} e) {\n\t$3\n} finally {\n\t$4\n}",
 		"description": "try..catch..finally",
 		"scope": "source.pde"
 	},
-	"pi2": {
-		"prefix": "pi",
+	"TWO_PI": {
+		"prefix": "TWO_PI",
 		"body": "TWO_PI",
 		"description": "TWO PI",
 		"scope": "source.pde"
@@ -1817,14 +1817,14 @@
 		"description": "unhex",
 		"scope": "source.pde"
 	},
-	"updatepixels": {
-		"prefix": "updatepixels",
+	"updatePixels": {
+		"prefix": "updatePixels",
 		"body": "updatePixels();",
 		"description": "updatePixels",
 		"scope": "source.pde"
 	},
-	"var": {
-		"prefix": "var",
+	"var_object": {
+		"prefix": "var_object",
 		"body": "${1:Object} ${2:o}${4: = new ${1}($3)};",
 		"description": "var object",
 		"scope": "source.pde"
@@ -1835,26 +1835,26 @@
 		"description": "var",
 		"scope": "source.pde"
 	},
-	"vec": {
-		"prefix": "vec",
+	"var_vector": {
+		"prefix": "var_vector",
 		"body": "PVector ${1:v} = new PVector(${2});",
 		"description": "var vector",
 		"scope": "source.pde"
 	},
-	"vec1": {
-		"prefix": "vec",
+	"var_vector_xy": {
+		"prefix": "var_vector_xy",
 		"body": "PVector ${1:v} = new PVector(${2:x},${3:y});",
 		"description": "var vector xy",
 		"scope": "source.pde"
 	},
-	"vec2": {
-		"prefix": "vec",
+	"var_vector_xyz": {
+		"prefix": "var_vector_xyz",
 		"body": "PVector ${1:v} = new PVector(${2:x},${3:y},${4:z});",
 		"description": "var vector xyz",
 		"scope": "source.pde"
 	},
-	"vertex": {
-		"prefix": "vertex",
+	"vertex_3D": {
+		"prefix": "vertex_3D",
 		"body": "vertex(${1:x}, ${2:y}, ${3:z}${6:, ${4:u}, ${5:v}});",
 		"description": "vertex 3D",
 		"scope": "source.pde"
@@ -1871,8 +1871,8 @@
 		"description": "while",
 		"scope": "source.pde"
 	},
-	"time5": {
-		"prefix": "time",
+	"year": {
+		"prefix": "year",
 		"body": "year()",
 		"description": "year",
 		"scope": "source.pde"


### PR DESCRIPTION
Replace the numbered prefix to more detailed items.

Before:
![图片](https://user-images.githubusercontent.com/17522475/65826195-25a36780-e2b3-11e9-9b72-afd749411ca6.png)
After:
![图片](https://user-images.githubusercontent.com/17522475/65826196-2936ee80-e2b3-11e9-8040-cb97324437bf.png)

How is this done?
```python
import json
with open("snippets.json") as f:
    snippets = json.load(f)
another_dict = {}
for k,v in snippets.items():
#     print(k,"_".join(v["description"].split()))
    concated = "_".join(v["description"].split())
    if not concated in snippets:
        if not concated in another_dict: 
            another_dict[concated] = v.copy()
            another_dict[concated]["prefix"] = concated
        else:
            print(concated, v)
    else:
        another_dict[k] = v.copy()
# output:
# keyPressed {'prefix': 'key', 'body': 'void keyPressed() {\n\t${1}\n}', 'description': 'keyPressed', 'scope': 'source.pde'}
# mousePressed {'prefix': 'mouse', 'body': 'void mousePressed() {\n\t${1}\n}', 'description': 'mousePressed', 'scope': 'source.pde'}
# These two have duplicated var name and method, so add the `_func` postfix for method.
with open('edited.json','w') as f:
    json.dump(another_dict, f)
```
