### PR TITLE
Add type property to execute a sketch on Windows

### DIFF
--- a/ProcessingTasks.json
+++ b/ProcessingTasks.json
@@ -22,6 +22,7 @@
 		"--run"
 	  ],
       "windows": {
+        "type": "process",
         "args": [
           "--force",
           {


### PR DESCRIPTION
If the "type" is "shell", the terminal show this message and it can't compile & run the code on Windows.
`The terminal process terminated with exit code: 1`